### PR TITLE
Stop matching 'eggs' or 'ices'

### DIFF
--- a/jargone.js
+++ b/jargone.js
@@ -78,7 +78,12 @@ javascript:(function () {
 
 	var p = document.getElementsByTagName('p'); 
 	for (var j = 0; j < words.length; j++) { // for each word
-	    var regex = new RegExp('(\\b' + words[j] + '\\b)', 'ig');
+	    var word = '\\b' + words[j].replace(/([.*+?^=!:${}()|[\]\/\\])/g, "\\$1");
+	    if (word.slice(-1) != '.') {
+	        word = word + '\\b';
+	    }
+	    var regex = new RegExp('(' + word + ')', 'ig');
+
 	    for (var i = 0; i < p.length; i++) {
 	        var para = p[i].innerHTML;
 	        para = para.replace(regex, '<span style=\'background-color: #FFFF88\'>$1<\/span>'); // TODO: replace this dirty hack with something a bit nicer


### PR DESCRIPTION
Escape all regex characters in the word list, and only stick a \b at the end if the last character isn't a "." (that latter is a bit specific to this word list, but seems okay for now).
