### PR TITLE
Make title markdown render properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#Jargone
+# Jargone
 
 Jargone is [a bookmarklet](http://rooreynolds.github.com/jargone/) for highlighting [jargon words](https://www.gov.uk/designprinciples/styleguide#item_4_1_3) on any page.
 
 <a href="http://www.flickr.com/photos/rooreynolds/8435984971/"><img src="http://farm9.staticflickr.com/8510/8435984971_e3f76721c0_o.png" width="757" height="547"></a>
 
-##Installation
+## Installation
 
 Follow the two step [installation instructions](http://rooreynolds.github.com/jargone/)
 
-##Building
+## Building
 
 To add to the jargon list:
 
@@ -18,7 +18,7 @@ To add to the jargon list:
  - the resulting new `jargone.js` can then be committed to GitHub
  
  
-##Other tools
+## Other tools
 
 There are some other tools and services you might find useful. 
 


### PR DESCRIPTION
Markdown requires a space after the # character to render.